### PR TITLE
Add support for combination selectors compilation

### DIFF
--- a/compile_test.go
+++ b/compile_test.go
@@ -116,6 +116,11 @@ func TestCompileSelector(t *testing.T) {
 			"p :empty",
 			[]string{`<a id="foo"></a>`},
 		},
+		{
+			`<div><p><a id="foo"></a></p></div>`,
+			"div > p a",
+			[]string{`<a id="foo"></a>`},
+		},
 	}
 	for i, tt := range tests {
 		l, err := newLexer(tt.expr)

--- a/lex_test.go
+++ b/lex_test.go
@@ -171,6 +171,11 @@ func TestLexer(t *testing.T) {
 			token{typeIdent, "p", 7}, token{typeComma, ",", 8}, token{typeSpace, " ", 9},
 			token{typeIdent, "p", 10}, token{typeEOF, "", 11},
 		}},
+		{"span > p p", []token{
+			token{typeIdent, "span", 0}, token{typeGreater, " >", 4}, token{typeSpace, " ", 6},
+			token{typeIdent, "p", 7}, token{typeSpace, " ", 8},
+			token{typeIdent, "p", 9}, token{typeEOF, "", 10},
+		}},
 		{"-2n-1", []token{
 			token{typeSub, "-", 0}, token{typeDimension, "2n-1", 1}, token{typeEOF, "", 5},
 		}},

--- a/testdata/fuzz-samples.css
+++ b/testdata/fuzz-samples.css
@@ -2,6 +2,7 @@ span > p, p
 p ~ span
 div > p
 span > p
+span > p div
 div div
 div *
 div .hi


### PR DESCRIPTION
For example:
foo > a span

Previously it would only compile up until a and not include the span