### PR TITLE
Fix class selector to allow spaces

### DIFF
--- a/css.go
+++ b/css.go
@@ -378,8 +378,16 @@ func (s *subclassSelectorMatcher) match(n *html.Node) bool {
 
 	if s.classSelector != "" {
 		for _, a := range n.Attr {
-			if a.Key == "class" && a.Val == s.classSelector {
-				return true
+			if a.Key == "class" {
+				cls := strings.Split(a.Val, " ")
+				for _, cl := range cls {
+					if cl == "" {
+						continue
+					}
+					if cl == s.classSelector {
+						return true
+					}
+				}
 			}
 		}
 		return false


### PR DESCRIPTION
The class selector currently doesn't split the class value in order to
recognize individual classes when multiple classes are provided in an
element node.

For example, the selector text ".a" will fail to recognize the div
element `<div class="a b"></div>`.

This pull request fixes that.