### PR TITLE
Make the type selector work for UPPER case elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # CSS selectors in Go
 
+This library is a fork of [github.com/ericchiang/css](https://github.com/ericchiang/css) fixing issues experienced using [Gost-DOM](https://github.com/gost-dom/browser).
+
+Note. This fork starts at version 0.1.0, as I imagine adding significant chagnes
+to the public API, allowing it consume an interface; rather than the specific golang.org/x/net/html
+
+---
+
 [![Go Reference](https://pkg.go.dev/badge/github.com/ericchiang/css.svg)](https://pkg.go.dev/github.com/ericchiang/css)
 
 This package implements a CSS selector compiler for Go's HTML parsing package golang.org/x/net/html.

--- a/css.go
+++ b/css.go
@@ -753,7 +753,7 @@ func (c *compiler) typeSelector(s *typeSelector) *typeSelectorMatcher {
 	if s.value == "*" {
 		m.allAtoms = true
 	} else {
-		a := atom.Lookup([]byte(s.value))
+		a := atom.Lookup([]byte(strings.ToLower(s.value)))
 		if a == 0 {
 			if c.errorf(s.pos, "unrecognized node name: %s", s.value) {
 				return nil

--- a/css_test.go
+++ b/css_test.go
@@ -338,7 +338,7 @@ var selectorTests = []selectorTest{
 		},
 	},
 	{
-		"body p em", // https://github.com/ericchiang/css/issues/7
+		"body p em", // https://github.com/gost-dom/css/issues/7
 		`
 				<html>
 					<body>

--- a/css_test.go
+++ b/css_test.go
@@ -100,6 +100,11 @@ type selectorTest struct {
 
 var selectorTests = []selectorTest{
 	{
+		"A",
+		`<h1><a></a></h1>`,
+		[]string{`<a></a>`},
+	},
+	{
 		"a",
 		`<h1><a></a></h1>`,
 		[]string{`<a></a>`},
@@ -801,7 +806,13 @@ func TestSelector(t *testing.T) {
 			got = append(got, b.String())
 		}
 		if diff := cmp.Diff(test.want, got); diff != "" {
-			t.Errorf("Selecting %q (%s) from %s returned diff (-want, +got): %s", test.sel, s, in, diff)
+			t.Errorf(
+				"Selecting %q (%s) from %s returned diff (-want, +got): %s",
+				test.sel,
+				s,
+				in,
+				diff,
+			)
 		}
 	}
 }
@@ -821,11 +832,21 @@ func TestBadSelector(t *testing.T) {
 		}
 		var perr *ParseError
 		if !errors.As(err, &perr) {
-			t.Errorf("Expected parsing %s to return error of type *ParseError, got %T: %v", test.sel, err, err)
+			t.Errorf(
+				"Expected parsing %s to return error of type *ParseError, got %T: %v",
+				test.sel,
+				err,
+				err,
+			)
 			continue
 		}
 		if test.pos != perr.Pos {
-			t.Errorf("Parsing %s returned unexpected position, got=%d, want=%d", test.sel, perr.Pos, test.pos)
+			t.Errorf(
+				"Parsing %s returned unexpected position, got=%d, want=%d",
+				test.sel,
+				perr.Pos,
+				test.pos,
+			)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ericchiang/css
+module github.com/gost-dom/css
 
 go 1.15
 


### PR DESCRIPTION
The parser generates an error when parsing an element name in upper case, e.g., `css.Parse("DIV")`, which _is_ working in a browser.

I use this library for [gost](http://github.com/gost-dom/browser), a headless browser _with_ JavaScript execution, primarily for testing Go/HTMX stack.

HTMX generates such selectors, as it constructs them from `tagName` which returns uppercase tag names for HTML elements, resulting in selectors like `DIV[id='root']`.

I believe this should fix the issue, I hope that there are not aspects of the problem I'm unaware of.